### PR TITLE
Fix typo, use "rewards" instead of "reward" in cartpole_naive_dqn.py

### DIFF
--- a/naive_deep_q_learning/cartpole_naive_dqn.py
+++ b/naive_deep_q_learning/cartpole_naive_dqn.py
@@ -64,7 +64,7 @@ class Agent():
 
         q_next = self.Q.forward(states_).max()
 
-        q_target = reward + self.gamma*q_next
+        q_target = rewards + self.gamma*q_next
 
         loss = self.Q.loss(q_target, q_pred).to(self.Q.device)
         loss.backward()


### PR DESCRIPTION
According to Phil's [comment](https://www.udemy.com/course/deep-q-learning-from-paper-to-code/learn/lecture/17009546#questions/10366136), we should ideally use parameter rewards although the code still runs fine with parameter reward.

> Ah, good point. Yes, this is a typo.
> Fortunately, it's a typo that doesn't affect the outcome.
> The reward (the numpy array) isn't connected to the graph, so apparently PyTorch is just as happy dealing with a numpy array as it is a tensor.
