### PR TITLE
Fix uint8 issue for newer versions of PyTorch 

### DIFF
--- a/DDQN/ddqn_agent.py
+++ b/DDQN/ddqn_agent.py
@@ -42,7 +42,7 @@ class DDQNAgent(object):
 
         states = T.tensor(state).to(self.q_eval.device)
         rewards = T.tensor(reward).to(self.q_eval.device)
-        dones = T.tensor(done).to(self.q_eval.device)
+        dones = T.tensor(done, dtype=T.bool).to(self.q_eval.device)
         actions = T.tensor(action).to(self.q_eval.device)
         states_ = T.tensor(new_state).to(self.q_eval.device)
 
@@ -83,7 +83,7 @@ class DDQNAgent(object):
         q_next = self.q_next.forward(states_)
         q_eval = self.q_eval.forward(states_)
 
-        max_actions = T.argmax(q_eval, dim=1)
+        max_actions = T.argmax(q_eval, dim=1).detach()
         q_next[dones] = 0.0
 
         q_target = rewards + self.gamma*q_next[indices, max_actions]

--- a/DQN/dqn_agent.py
+++ b/DQN/dqn_agent.py
@@ -53,7 +53,7 @@ class DQNAgent(object):
 
         states = T.tensor(state).to(self.q_eval.device)
         rewards = T.tensor(reward).to(self.q_eval.device)
-        dones = T.tensor(done).to(self.q_eval.device)
+        dones = T.tensor(done, dtype=T.bool).to(self.q_eval.device)
         actions = T.tensor(action).to(self.q_eval.device)
         states_ = T.tensor(new_state).to(self.q_eval.device)
 

--- a/DuelingDDQN/dueling_ddqn_agent.py
+++ b/DuelingDDQN/dueling_ddqn_agent.py
@@ -42,7 +42,7 @@ class DuelingDDQNAgent(object):
 
         states = T.tensor(state).to(self.q_eval.device)
         rewards = T.tensor(reward).to(self.q_eval.device)
-        dones = T.tensor(done).to(self.q_eval.device)
+        dones = T.tensor(done, dtype=T.bool).to(self.q_eval.device)
         actions = T.tensor(action).to(self.q_eval.device)
         states_ = T.tensor(new_state).to(self.q_eval.device)
 
@@ -92,7 +92,7 @@ class DuelingDDQNAgent(object):
 
         q_eval = T.add(V_s_eval, (A_s_eval - A_s_eval.mean(dim=1,keepdim=True)))
 
-        max_actions = T.argmax(q_eval, dim=1)
+        max_actions = T.argmax(q_eval, dim=1).detach()
         q_next[dones] = 0.0
 
         q_target = rewards + self.gamma*q_next[indices, max_actions]

--- a/DuelingDQN/dueling_dqn_agent.py
+++ b/DuelingDQN/dueling_dqn_agent.py
@@ -42,7 +42,7 @@ class DuelingDQNAgent(object):
 
         states = T.tensor(state).to(self.q_eval.device)
         rewards = T.tensor(reward).to(self.q_eval.device)
-        dones = T.tensor(done).to(self.q_eval.device)
+        dones = T.tensor(done, dtype=T.bool).to(self.q_eval.device)
         actions = T.tensor(action).to(self.q_eval.device)
         states_ = T.tensor(new_state).to(self.q_eval.device)
 


### PR DESCRIPTION
uint8 is deprecated in recent versions of Pytorch(1.2 or higher), have updated the variable to tensor.bool()