### PR TITLE
Fix for Gym environment framework changes

### DIFF
--- a/naive_deep_q_learning/cartpole_naive_dqn.py
+++ b/naive_deep_q_learning/cartpole_naive_dqn.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
 
         while not done:
             action = agent.choose_action(obs)
-            obs_, reward, done, info = env.step(action)
+            obs_, reward, done, _, info = env.step(action)
             score += reward
             agent.learn(obs, action, reward, obs_)
             obs = obs_

--- a/naive_deep_q_learning/cartpole_naive_dqn.py
+++ b/naive_deep_q_learning/cartpole_naive_dqn.py
@@ -83,7 +83,7 @@ if __name__ == '__main__':
     for i in range(n_games):
         score = 0
         done = False
-        obs = env.reset()
+        obs = env.reset()[0]
 
         while not done:
             action = agent.choose_action(obs)


### PR DESCRIPTION
env.reset() returns an observation and info. This fixes issues with the expected size of a tuple. 

from gym library api https://www.gymlibrary.dev/api/core/#gym.Env.reset
> RETURNS:
> observation (object) – Observation of the initial state. This will be an element of [observation_space](https://www.gymlibrary.dev/api/core/#gym.Env.observation_space) (typically a numpy array) and is analogous to the observation returned by [step()](https://www.gymlibrary.dev/api/core/#gym.Env.step).
> 
> **info** (dictionary) – This dictionary contains auxiliary information complementing observation. It should be analogous to the info returned by [step()](https://www.gymlibrary.dev/api/core/#gym.Env.step).
> 

env.step returns a tuple with an additional variable. adding a throwaway variable fixes errors with expected return lengths.

from gym library api https://www.gymlibrary.dev/api/core/#gym.Env.step
> Accepts an action and returns either a tuple (observation, reward, terminated, **truncated**, info).